### PR TITLE
Pin depenencies to specific versions

### DIFF
--- a/normalize.py
+++ b/normalize.py
@@ -12,6 +12,7 @@ line are nicknames for the canonical name.
 - There are no repeated lines
 - All lines are sorted by the first name in the line
 """
+
 from __future__ import annotations
 
 import argparse

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -24,6 +24,7 @@ This post https://stackoverflow.com/q/61624018/5156887
 makes it seem like a custom setuptools script is the only way. So that's what I did,
 but using hatch.
 """
+
 import shutil
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,7 +39,7 @@ path = "src/nicknames/_version.py"
 
 [tool.hatch.envs.default]
 dependencies = [
-  "pytest",
+  "pytest==7.4.4",  # The last version that supports pythoh 3.7
   "ruff==0.4.1",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,13 +40,13 @@ path = "src/nicknames/_version.py"
 [tool.hatch.envs.default]
 dependencies = [
   "pytest",
-  "ruff>=0.1.6",
+  "ruff==0.4.1",
 ]
 
 [tool.hatch.envs.default.scripts]
 # Run these in the repo root to get ALL python files
-lint = "python -m ruff format --check .. && python -m ruff .."
-fmt = "python -m ruff --fix .. && python -m ruff format .."
+lint = "python -m ruff format --check .. && python -m ruff check .."
+fmt = "python -m ruff check --fix .. && python -m ruff format .."
 test = "pytest"
 test-CI = "pytest -Werror"
 sync = "python ../normalize.py && python ../sql/generate_sql.py"
@@ -55,7 +55,7 @@ sync = "python ../normalize.py && python ../sql/generate_sql.py"
 [tool.hatch.build.hooks.custom]
 
 [tool.ruff]
-select = [
+lint.select = [
   "E",  # pyflakes
   "F",  # pyflakes
   "I",  # isort

--- a/sql/generate_sql.py
+++ b/sql/generate_sql.py
@@ -1,4 +1,5 @@
 """Script to auto-generate SQL scripts from the canonical CSV file."""
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
We were getting CI failures due to ruff auto-upgrading

Ideally we would use PDM or some project manager tool that has a lockfile, but I don't want to spend the effort at this point.