### PR TITLE
Chris/Kris variants using f, Maximilian, Nicolas

### DIFF
--- a/names.csv
+++ b/names.csv
@@ -576,6 +576,7 @@ christine,has_nickname,crissy
 christine,has_nickname,kris
 christine,has_nickname,kristy
 christine,has_nickname,tina
+christoffer,has_nickname,chris
 christoph,has_nickname,chris
 christopher,has_nickname,chris
 christopher,has_nickname,kit
@@ -1525,6 +1526,10 @@ kristine,has_nickname,crissy
 kristine,has_nickname,kris
 kristine,has_nickname,kristy
 kristine,has_nickname,tina
+kristofer,has_nickname,chris
+kristofer,has_nickname,kris
+kristoffer,has_nickname,chris
+kristoffer,has_nickname,kris
 kristopher,has_nickname,chris
 kristopher,has_nickname,kris
 kristy,has_nickname,chris
@@ -1858,6 +1863,7 @@ maureen,has_nickname,mary
 maurice,has_nickname,morey
 mavery,has_nickname,mave
 mavine,has_nickname,mave
+maximilian,has_nickname,max
 maximillian,has_nickname,max
 maxine,has_nickname,max
 maxwell,has_nickname,max
@@ -2005,6 +2011,11 @@ nicodemus,has_nickname,nick
 nicodemus,has_nickname,nickie
 nicodemus,has_nickname,nicky
 nicodemus,has_nickname,nico
+nicolas,has_nickname,nic
+nicolas,has_nickname,nick
+nicolas,has_nickname,nickie
+nicolas,has_nickname,nicky
+nicolas,has_nickname,nico
 nicole,has_nickname,cole
 nicole,has_nickname,nicki
 nicole,has_nickname,nicky


### PR DESCRIPTION
https://en.wiktionary.org/wiki/Christoffer
https://en.wiktionary.org/wiki/Kristoffer
https://en.wiktionary.org/wiki/Kristofer
https://en.wiktionary.org/wiki/Maximilian
https://en.wiktionary.org/wiki/Nicolas (could do more: https://en.wiktionary.org/wiki/Niklas)

---

exciting finding this bc I privately maintain nicknames (in regex form since there's obviously frequent overlap):
```regex
spencer?
pauly?
dust(y|in)
josh(ua)?
pete(r|y)?
doug(ie|ey|las)?
pat(sy|ti|ty|ricia|ience)?
mi(chael|guel|key?)
ben(ny|jy|son|jamin|edict|nett?)?
jack?(son)?
vin(ny|nie|ce(nt|nzo)?)?
al(ex(ander)?)?
wes(t?le?y)?
brad(l?e?y|ford)?
max(imus|well?|imill?ian)?
cam(eron|m?(y|ie?))?
dan(iel|n?(y|ie?))?
dav(i?ey?|id)
th?om(m?(y|ie?)|as)?
sam(uel|m?(y|ie?)|p?son)?
(james|jim(m?(y|ie?)|bo)?)
[bw]ill(y|ie|iam)?
[rb]ob(bie|by|erto?)?
(pre)?scott?(y|ie?)?
[ck]ath?(erine|leen|y|i?e?)?
matt?(y|ie?|eo|hew|hieu|hias|h?ilda)?
joh?n(ny|nie|[oa]th[ao]n)?
za(c[hk]?|k)([ae]r(y|iah))?
[cs]her(r?yl?|r?ie?)?
(ch|k)ris(to(ph|ff?)(er)?)?
...
peggy|margaret # fallback to similar verbosity when regex isn't desired
```
For simpler regexes, I occasionally intentionally include corner cases like `Billiam`/`Boberto?`/`Prescott(y|ie)` since I'm matching real datasets, so it's no issue that they aren't typical. Inversely, false positive matches are detrimental, so I exclude looser matches like:
https://github.com/carltonnorthern/nicknames/blob/7377e59e030543f1c1797550fed83a073ba85282/names.csv#L165

Curious if you'd consider excluding or separating looser matches!